### PR TITLE
remove photo_id and icon field from create event API

### DIFF
--- a/backend/src/main/java/DAL/EventController.java
+++ b/backend/src/main/java/DAL/EventController.java
@@ -31,8 +31,8 @@ public class EventController {
       String stmt =
           String.format(
               "INSERT INTO %s (event_code, event_name, description, host_id, is_public, is_deleted, location_name, latitude, "
-                  + "longitude, start_time, end_time, max_participants, curr_num_participants, photo_id, icon, address, created_at) "
-                  + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
+                  + "longitude, start_time, end_time, max_participants, curr_num_participants, address, created_at) "
+                  + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
               TABLE_NAME);
       try (PreparedStatement createEventStmt = conn.prepareStatement(stmt)) {
         createEventStmt.setString(1, event.event_code);
@@ -48,11 +48,8 @@ public class EventController {
         createEventStmt.setTimestamp(11, Timestamp.valueOf(event.end_time));
         createEventStmt.setInt(12, event.max_participants);
         createEventStmt.setInt(13, event.curr_num_participants);
-        createEventStmt.setString(14, event.photo_id);
-        createEventStmt.setString(15, event.icon);
-        createEventStmt.setString(16, event.address);
-        createEventStmt.setTimestamp(17, new Timestamp(System.currentTimeMillis()));
-        System.out.println(stmt);
+        createEventStmt.setString(14, event.address);
+        createEventStmt.setTimestamp(15, new Timestamp(System.currentTimeMillis()));
         createEventStmt.executeUpdate();
         resetIdIndex(pool);
       }


### PR DESCRIPTION
We are now storing images to Firestorage and we don't need the photo_id field in the database now. Also, we don't support custom icon as of now. I also remove the icon field from the controller.
I altered the database table so that photo_id and icon fields no longer have the not null restriction.